### PR TITLE
 Scala 2.10.0 + smarter way to find scala jars

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "scct"
 
 version := "0.2-SNAPSHOT"
 
-scalaVersion := "2.10.0-RC3"
+scalaVersion := "2.10.0"
 
-crossScalaVersions := Seq("2.10.0-RC3")
+crossScalaVersions := Seq("2.10.0")
 
 libraryDependencies <+= (scalaVersion) { v =>
   "org.scala-lang" % "scala-compiler" % v % "provided"

--- a/src/test/scala/reaktor/scct/InstrumentationSpec.scala
+++ b/src/test/scala/reaktor/scct/InstrumentationSpec.scala
@@ -61,7 +61,7 @@ trait InstrumentationSupport {
 
   def locateCompiledClasses() = {
     val scalaTargetDir = scalaVersion match {
-      case "2.10.0-RC3" => "2.10"
+      case version if version.startsWith("2.10.0") => "2.10"
       case x => x
     }
     val first = new File("./target/scala-"+scalaTargetDir+"/classes")
@@ -91,8 +91,19 @@ trait InstrumentationSupport {
       // Probably IDEA with project dir instead of module dir as working dir
       scalaJars.map("./scct/project/boot/scala-"+scalaVersion+"/lib/"+_)
     } else {
-      throw new FileNotFoundException("scala jars not found. Check InstrumentationSpec:locateScalaJars")
+      //Magic
+      //throw new FileNotFoundException("scala jars not found. Check InstrumentationSpec:locateScalaJars: " + f.getPath)
+      List(jarPathOfClass("scala.Some"),jarPathOfClass("scala.tools.nsc.Interpreter") )
     }
+  }
+  
+  def jarPathOfClass(className: String) = {
+    val resource = className.split('.').mkString("/", "/", ".class")
+    val path = getClass.getResource(resource).getPath
+    println("path " + path)
+    val indexOfFile = path.indexOf("file:")
+    val indexOfSeparator = path.lastIndexOf('!')
+    path.substring(indexOfFile, indexOfSeparator).replace("file:","")
   }
 
   def compile(line: String): PluginRunner = {

--- a/src/test/scala/reaktor/scct/InstrumentationSpec.scala
+++ b/src/test/scala/reaktor/scct/InstrumentationSpec.scala
@@ -79,22 +79,7 @@ trait InstrumentationSupport {
   }
 
   def locateScalaJars() = {
-    val scalaJars = List("scala-compiler.jar", "scala-library.jar")
-    val userHome = System.getProperty("user.home")
-    if (new File(System.getProperty("user.home") + "/.sbt/boot/scala-"+scalaVersion+"/lib/"+ scalaJars.head).exists) {
-      // sbt 0.11+ with global boot dirs
-      scalaJars.map(userHome + "/.sbt/boot/scala-"+scalaVersion+"/lib/"+_)
-    } else if (new File("./project/boot/scala-"+scalaVersion+"/lib/" + scalaJars.head).exists) {
-      // sbt 0.7.7 and such, project-specific boot dirs
-      scalaJars.map("./project/boot/scala-"+scalaVersion+"/lib/"+_)
-    } else if (new File("./scct/project/boot/scala-"+scalaVersion+"/lib/" + scalaJars.head).exists) {
-      // Probably IDEA with project dir instead of module dir as working dir
-      scalaJars.map("./scct/project/boot/scala-"+scalaVersion+"/lib/"+_)
-    } else {
-      //Magic
-      //throw new FileNotFoundException("scala jars not found. Check InstrumentationSpec:locateScalaJars: " + f.getPath)
-      List(jarPathOfClass("scala.Some"),jarPathOfClass("scala.tools.nsc.Interpreter") )
-    }
+    List(jarPathOfClass("scala.Some"),jarPathOfClass("scala.tools.nsc.Interpreter") )
   }
   
   def jarPathOfClass(className: String) = {

--- a/src/test/scala/reaktor/scct/InstrumentationSpec.scala
+++ b/src/test/scala/reaktor/scct/InstrumentationSpec.scala
@@ -100,10 +100,8 @@ trait InstrumentationSupport {
   def jarPathOfClass(className: String) = {
     val resource = className.split('.').mkString("/", "/", ".class")
     val path = getClass.getResource(resource).getPath
-    println("path " + path)
-    val indexOfFile = path.indexOf("file:")
     val indexOfSeparator = path.lastIndexOf('!')
-    path.substring(indexOfFile, indexOfSeparator).replace("file:","")
+    path.substring(0,indexOfSeparator).replace("file:","")
   }
 
   def compile(line: String): PluginRunner = {


### PR DESCRIPTION
@eerok 

cc---

Updated Scala version of the project to 2.10.0.

Also most of us here the sbt-extras launcher (https://github.com/paulp/sbt-extras/blob/master/sbt) which helps dealing with multiple Scala/SBT versions. The Scala jar finding magic did not quite work for me, so I replaced it with something ripped of from here: http://speaking-my-language.blogspot.com.au/2009/11/embedded-scala-interpreter.html.

Do you think something like this would work?

PS. I can/will clean up the code a bit, just wanted to send an early preview.
