### PR TITLE
SBT 0.13 Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "scct"
 
 version := "0.2-SNAPSHOT"
 
-scalaVersion := "2.10.0-RC3"
+scalaVersion := "2.10.2"
 
-crossScalaVersions := Seq("2.10.0-RC3")
+crossScalaVersions := Seq("2.10.2")
 
 libraryDependencies <+= (scalaVersion) { v =>
   "org.scala-lang" % "scala-compiler" % v % "provided"

--- a/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
+++ b/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
@@ -57,7 +57,7 @@ class ScctTransformComponent(val global: Global, val opts:ScctInstrumentPluginOp
   var saveData = true
   var counter = 0
   var data: List[CoveredBlock] = Nil
-  lazy val coverageFile = new File(global.settings.outdir.value, "coverage.data")
+  lazy val coverageFile = new File(global.settings.outputDirs.getSingleOutput.map(_.toString).getOrElse("/"), "coverage.data")
 
   def newId: Int = {
     require(counter < Integer.MAX_VALUE)


### PR DESCRIPTION
I had to make this somewhat ugly change to scct for sbt-scct to work with sbt 0.13. `global.settings.outdir.value` returns null with sbt 0.13. Couldn't find anything in the sbt release notes to give a clue as to why this is.

Because this change only effects sbt 0.13, we only need it on `master` and not on the `2.9.2` branch (used for sbt 0.12)

Caveat: I haven't tested this change with a maven project yet, so I don't know what the impact of this change is for maven users.
