### PR TITLE
All Tests now passing - Fix for issue #4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 before_script: "sbt test:compile"
 script: "sbt test"
+# Using 2.10.3 for test on travis, otherwise we hit this bug:
+#  - https://issues.scala-lang.org/browse/SI-7775
 scala:
-  - "2.10.0-RC3"
+  - "2.10.3-RC2"

--- a/src/test/scala/reaktor/scct/InstrumentationSpec.scala
+++ b/src/test/scala/reaktor/scct/InstrumentationSpec.scala
@@ -61,7 +61,7 @@ trait InstrumentationSupport {
 
   def locateCompiledClasses() = {
     val scalaTargetDir = scalaVersion match {
-      case "2.10.0-RC3" => "2.10"
+      case x if x startsWith "2.10" => "2.10"
       case x => x
     }
     val first = new File("./target/scala-"+scalaTargetDir+"/classes")


### PR DESCRIPTION
Looks like the `ConcurrentModificationException` we were seeing in the tests running on travis is a bug [SI-7775](https://issues.scala-lang.org/browse/SI-7775) in scala.

I have no idea why this only happens on travis and not locally, but running the travis job with `2.10.3-RC2` (which contains the fix for SI-7775) means the test suite runs on travis with no problems.

All tests passing: https://travis-ci.org/SCCT/scct/builds/11940789
