### PR TITLE
Simplify settings for build.sbt in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install
 
 ### Add the plugin settings to your project, at build.sbt:
 
-    seq(ScctPlugin.instrumentSettings : _*)
+    ScctPlugin.instrumentSettings
 
 ### Run your unit tests :
 


### PR DESCRIPTION
Is `ScctPlugin.instrumentSettings` just the same as `seq(ScctPlugin.instrumentSettings : _*)` but simpler?
