### PR TITLE
Exclude by full class name (package + name) or by file path (relative to base dir).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib_managed/
 target/
 self-report/
 .idea
+.idea_modules

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "dmm.scct"
+organization := "com.sqality.scct"
 
 name := "scct"
 
@@ -18,7 +18,11 @@ libraryDependencies ++= Seq(
   "org.specs2"  %% "specs2"      % "1.14"  % "test"
 )
 
-publishTo := Some( Resolver.sftp("DMM Maven Repository", "freighter.boats.local", "/home/maven/repository") as("maven", "b0ats123") )
+publishTo <<= version { (v: String) =>
+  val nexus = "https://oss.sonatype.org/"
+  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
 
 testOptions in Test <+= (scalaVersion in Test) map { (scalaVer) => 
   Tests.Setup { () => System.setProperty("scct-test-scala-version", scalaVer) } 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "com.sqality.scct"
+organization := "dmm.scct"
 
 name := "scct"
 
@@ -18,11 +18,7 @@ libraryDependencies ++= Seq(
   "org.specs2"  %% "specs2"      % "1.14"  % "test"
 )
 
-publishTo <<= version { (v: String) => 
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
-  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
+publishTo := Some( Resolver.sftp("DMM Maven Repository", "freighter.boats.local", "/home/maven/repository") as("maven", "b0ats123") )
 
 testOptions in Test <+= (scalaVersion in Test) map { (scalaVer) => 
   Tests.Setup { () => System.setProperty("scct-test-scala-version", scalaVer) } 

--- a/src/main/scala/com/sqality/scct/Coverage.scala
+++ b/src/main/scala/com/sqality/scct/Coverage.scala
@@ -62,14 +62,8 @@ object Coverage {
     BinaryReporter.report(projectData, env.reportDir)
   }
 
-  private def filteredData: List[CoveredBlock] = {
-    env.excludes match {
-      case excludes: String => {
-        new CoverageFilter(excludes.split(",").filter(_.length > 0).map(_.r)).filter(dataValues)
-      }
-      case _ => dataValues
-    }
-  }
+  private def filteredData: List[CoveredBlock] =
+    CoverageFilter.filter(dataValues, env.excludeFiles, env.excludeClasses)
 
   private def setupShutdownHook {
     Runtime.getRuntime.addShutdownHook(new Thread {

--- a/src/main/scala/com/sqality/scct/CoverageFilter.scala
+++ b/src/main/scala/com/sqality/scct/CoverageFilter.scala
@@ -7,7 +7,8 @@ class CoverageFilter(excludeFiles: Array[Regex]) {
   private var debug = System.getProperty("scct.debug") == "true"
 
   private def isIncluded(block: CoveredBlock) = {
-    val isMatched = excludeFiles.filter(_.findFirstIn(block.name.sourceFile).isDefined).size > 0
+    val fullName = block.name.packageName + "." + block.name.className
+    val isMatched = excludeFiles.filter(_.findFirstIn(fullName).isDefined).size > 0
 
     if (debug && isMatched) println("scct : excluding " + block.name.sourceFile)
 

--- a/src/main/scala/com/sqality/scct/Env.scala
+++ b/src/main/scala/com/sqality/scct/Env.scala
@@ -2,6 +2,7 @@ package com.sqality.scct
 
 import java.io.File
 import java.util.Properties
+import scala.util.matching.Regex
 
 object Env {
   def sysOption(s: String) = {
@@ -40,7 +41,7 @@ object Env {
 
 class Env {
   val props = Env.envProps("/scct.properties")
-  def prop(x: String) = props.getProperty(x)
+  def prop(x: String): String = props.getProperty(x)
 
   lazy val projectId = prop("scct.project.name")
   lazy val baseDir = new File(prop("scct.basedir"))
@@ -50,8 +51,16 @@ class Env {
   /** Where the source files actually start from, so e.g. PROJECTHOME/src/main/scala/ */
   lazy val sourceDir = new File(prop("scct.source.dir"))
 
-  lazy val excludes = prop("scct.excluded.paths.regex")
+  lazy val excludeFiles = parseRegexArray(prop("scct.excluded.paths.regex"))
+  lazy val excludeClasses = parseRegexArray(prop("scct.excluded.classes.regex"))
 
   def coverageFile = Env.sysOption("scct.coverage.file").map(new File(_)).getOrElse(new File(getClass.getResource("/coverage.data").toURI))
+
+  private def parseRegexArray(commaSepRegexsOption: java.lang.String): List[Regex] = {
+    commaSepRegexsOption match {
+      case commaSepRegexs: String => commaSepRegexs.split(",").filter(_.length > 0).map(_.r).toList
+      case _ => List.empty
+    }
+  }
 }
 

--- a/src/test/scala/com/sqality/scct/CoverageFilterSpec.scala
+++ b/src/test/scala/com/sqality/scct/CoverageFilterSpec.scala
@@ -4,32 +4,60 @@ import org.specs2.mutable._
 import com.sqality.scct.ClassTypes.ClassType
 
 class CoverageFilterSpec extends Specification {
-
   "empty filter does pass thru" in {
-    val data = List(block("packageName"))
+    val data = List(block("/home/scct/file.scala", "com.package.MyClass"))
 
-    new CoverageFilter(Array()).filter(data) mustEqual data
+    CoverageFilter.filter(data, Nil, Nil) mustEqual data
   }
 
-  "non matching filter does pass thru" in {
-    val data = List(block("packageName"))
-    new CoverageFilter(Array("nonMatching".r)).filter(data) mustEqual data
+  "excludeClasses" should {
+    "non matching filter does pass thru" in {
+      val data = List(block("", "com.package.MyClass"))
+
+      CoverageFilter.filter(data, Nil, "nonMatching".r :: Nil) mustEqual data
+    }
+
+    "filter excludes matches" in {
+      val blockMatching = block("", "com.package.MyClass")
+      val blockNonMatching = block("", "nonmatching")
+
+      CoverageFilter.filter(List(blockMatching, blockNonMatching), Nil, "com.package*".r :: Nil) mustEqual List(blockNonMatching)
+    }
+
+    "multiple filters" in {
+      val blockMatching1 = block("", "com.package.MyClass")
+      val blockMatching2 = block("", "com.package.data.MyClass2")
+      val blockNonMatching = block("", "nonmatching")
+
+      CoverageFilter.filter(List(blockMatching1, blockMatching2, blockNonMatching), Nil,
+        "com.package.My*".r :: "com.package.data*".r :: Nil) mustEqual List(blockNonMatching)
+    }
   }
 
-  "filter excludes matches" in {
-    val blockMatching = block("MATCHINGPART")
-    val blockNonMatching = block("nonmatching")
+  "excludeFiles" should {
+    "non matching filter does pass thru" in {
+      val data = List(block("/home/scct/file.scala", "com.package.MyClass"))
 
-    new CoverageFilter(Array("MATCHINGPART".r)).filter(List(blockMatching, blockNonMatching)) mustEqual List(blockNonMatching)
+      CoverageFilter.filter(data, "nonMatching".r :: Nil, Nil) mustEqual data
+    }
+
+    "filter excludes matches" in {
+      val blockMatching = block("/home/scct/file.html", "com.package.MyClass")
+      val blockNonMatching = block("/home/scct/file.scala", "com.package.MyClass2")
+
+      CoverageFilter.filter(List(blockMatching, blockNonMatching), ".*.html".r :: Nil, Nil) mustEqual List(blockNonMatching)
+    }
+
+    "multiple filters" in {
+      val blockMatching1 = block("/home/scct/file.html", "com.package.MyClass")
+      val blockMatching2 = block("/home/scct/play/core.scala", "org.package.data.MyClass2")
+      val blockNonMatching = block("/home/scct/file.scala", "nonmatching")
+
+      CoverageFilter.filter(List(blockMatching1, blockMatching2, blockNonMatching),
+        ".*.html".r :: "/home/scct/play*".r :: Nil, Nil) mustEqual List(blockNonMatching)
+    }
   }
 
-  "multiple filters" in {
-    val blockMatching1 = block("MATCH1.suffix")
-    val blockMatching2 = block("MATCH2.suffix")
-    val blockNonMatching = block("nonmatching")
-
-    new CoverageFilter(Array("^MATCH1".r, "^MATCH2".r)).filter(List(blockMatching1, blockMatching2, blockNonMatching)) mustEqual List(blockNonMatching)
-  }
-
-  def block(packageName: String) = new CoveredBlock("c1", 1, Name(packageName, ClassTypes.Class, packageName, "className", "projectName"), 1, false)
+  private def block(fileName: String, packageName: String) =
+    new CoveredBlock("c1", 1, Name(fileName, ClassTypes.Class, packageName, "className", "projectName"), 1, false)
 }

--- a/src/test/scala/com/sqality/scct/ScctInstrumentPluginSpec.scala
+++ b/src/test/scala/com/sqality/scct/ScctInstrumentPluginSpec.scala
@@ -29,11 +29,16 @@ class ScctInstrumentPluginSpec extends Specification with Mockito {
       sut.options.baseDir.getName must not be empty
     }
     "be settable" in {
-      sut.processOptions(List("basedir:/base/dir", "projectId:myProject", "excludePackages:myRegex,yourRegex"), s => ())
+      sut.processOptions(List("basedir:/base/dir", "projectId:myProject", "excludePackages:myRegex,yourRegex",
+        "excludeFiles:regex1,regex2,regex3"), s => ())
       sut.options.projectId mustEqual "myProject"
       sut.options.baseDir.getAbsolutePath mustEqual "/base/dir"
-      sut.options.excludePackages must haveClass[Array[scala.util.matching.Regex]]
-      //sut.options.excludePackages mustEqual Array("myRegex".r, "yourRegex".r)
+      sut.options.excludeClasses must haveClass[Array[scala.util.matching.Regex]]
+      sut.options.excludeClasses(0).toString mustEqual "myRegex"
+      sut.options.excludeClasses(1).toString mustEqual "yourRegex"
+      sut.options.excludeFiles(0).toString mustEqual "regex1"
+      sut.options.excludeFiles(1).toString mustEqual "regex2"
+      sut.options.excludeFiles(2).toString mustEqual "regex3"
     }
     "report error" in {
       var err = ""


### PR DESCRIPTION
I have added new setting named "scct.excluded.classes.regex" that behaves the same way as "scct.excluded.paths.regex". One uses full class name, the other relative file path. Unit tests are updates also.
